### PR TITLE
[WIP] Attempt to be able to also transcribe html with innert tags (#3).

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "webpack --mode=production --config config/webpack.config.js"
   },
   "devDependencies": {
+    "ansi-regex": ">=5.0.1",
     "copy-webpack-plugin": "^6.4.1",
     "css-loader": "^4.3.0",
     "file-loader": "^6.2.0",
@@ -15,10 +16,10 @@
     "size-plugin": "^2.0.2",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",
-    "webpack-merge": "^5.8.0",
-    "ansi-regex": ">=5.0.1"
+    "webpack-merge": "^5.8.0"
   },
   "dependencies": {
-    "@andalugeeks/andaluh": "^1.1.8"
+    "@andalugeeks/andaluh": "^1.1.8",
+    "jssoup": "0.0.15"
   }
 }

--- a/public/test.html
+++ b/public/test.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+<title>Este es el titulo</title>
+</head>
+
+<body>
+<p>
+    Texto para ser transcrito
+    <a href="https://andaluh.es"> pero como hay un inner link </a>
+    pues ya no se transcribe
+</p>
+<p>Otro texto para ser transcrito <a href="@">con otro enlace</a>.</p>
+</body>
+</html>

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const andaluh = require('@andalugeeks/andaluh');
+const JSSoup = require('jssoup').default;
 const EPA = new andaluh.EPA();
 
 chrome.storage.local.get('andaluh', function (options) {
@@ -38,14 +39,25 @@ chrome.storage.local.get('andaluh', function (options) {
         b:not(.andaluh-translated)");
 
       for (const text of texts) {
-        // If innerText contains any HTML tags, ignore it
-        if (text.innerHTML.indexOf('<') === -1) {
-          // Translate the text
-          const translated = EPA.transcript(text.innerHTML, options.vaf, options.vvf, true);
-          // Update the text
-          text.innerHTML = translated;
-          text.classList.add('andaluh-translated');
+        var soup = new JSSoup(text.innerHTML);
+        for (var element of soup.descendants) {
+          // console.log(element.constructor.name);
+          // console.log(element);
+          if (element.constructor.name === 'SoupString') {
+            if (element.string !== null) {
+              console.log(element);
+              var newElement = element;
+              newElement._text = EPA.transcript(element._text, options.vaf, options.vvf, true);
+              element.replaceWith(newElement);
+              // element._text = EPA.transcript(element._text, options.vaf, options.vvf, true);
+              if (newElement.classList) {
+                newElement.classList.add('andaluh-translated');
+              }
+              console.log(newElement);
+            }
+          }
         }
+        text.innerHTML = soup;
       }
     }
 


### PR DESCRIPTION
This works with the inner tags, but I have several concerns yet:

1. Adds another package, making the extension bigger: https://github.com/chishui/JSSoup
2. White space is not always kept. Not sure if this is a problem with JSSoup, or EPA lib. I'm guessing JSSoup.toString().
3. Performance. The previous used classes for not transcribing the same content more than once, but this eliminates that option. 